### PR TITLE
Simplify hoster agreements

### DIFF
--- a/client/components/orders/order-detail.component.html
+++ b/client/components/orders/order-detail.component.html
@@ -33,8 +33,16 @@
     <div *ngIf="[statuses.SIGNED, statuses.SENT].includes(nodeOrder.status)">
       <img [src]="nodeOrder.arrival_qr_code_url" style="max-width: 400px;"/>
     </div>
-    <button *ngIf="canCancel()" md-button (click)="cancelOrder()" color="warn">{{ 'tff.cancel_order' | translate }}
+    <button *ngIf="canCancel()" md-button (click)="setOrderStatus(statuses.CANCELED)" color="warn">
+      {{ 'tff.cancel_order' | translate }}
     </button>
-    <button *ngIf="canMarkAsSent()" md-button (click)="markAsSent()">{{ 'tff.mark_as_sent' | translate }}</button>
+    <button *ngIf="canMarkAsSent()" md-button (click)="setOrderStatus(statuses.SENT)">
+      {{ 'tff.mark_as_sent' | translate }}
+    </button>
+    <button *ngIf="canApprove()" md-button (click)="setOrderStatus(statuses.APPROVED)">
+      {{ 'tff.approve_order' | translate }}
+    </button>
   </div>
+  <tff-api-request-status [status]="status"></tff-api-request-status>
+  <tff-api-request-status [status]="updateStatus"></tff-api-request-status>
 </div>

--- a/client/components/orders/order-detail.component.ts
+++ b/client/components/orders/order-detail.component.ts
@@ -27,19 +27,19 @@ export class OrderDetailComponent {
     return this.translate.instant(ORDER_STATUSES[ this.nodeOrder.status ]);
   }
 
-  markAsSent() {
-    this.onUpdate.emit(Object.assign({}, this.nodeOrder, { status: NodeOrderStatuses.SENT }));
-  }
-
-  cancelOrder() {
-    this.onUpdate.emit(Object.assign({}, this.nodeOrder, { status: NodeOrderStatuses.CANCELED }));
-  }
-
   canCancel() {
-    return [ NodeOrderStatuses.SIGNED, NodeOrderStatuses.CREATED ].includes(this.nodeOrder.status);
+    return [ NodeOrderStatuses.SIGNED, NodeOrderStatuses.APPROVED, NodeOrderStatuses.WAITING_APPROVAL ].includes(this.nodeOrder.status);
   }
 
   canMarkAsSent() {
     return NodeOrderStatuses.SIGNED === this.nodeOrder.status;
+  }
+
+  canApprove() {
+    return NodeOrderStatuses.WAITING_APPROVAL === this.nodeOrder.status;
+  }
+
+  setOrderStatus(status: NodeOrderStatuses) {
+    this.onUpdate.emit(Object.assign({}, this.nodeOrder, { status: status }));
   }
 }

--- a/client/components/orders/order-list.component.html
+++ b/client/components/orders/order-list.component.html
@@ -1,5 +1,5 @@
 <div class="orders-content">
-  <md-select [(ngModel)]="status" (ngModelChange)="onStatusChange()">
+  <md-select [(ngModel)]="status" (ngModelChange)="onStatusChange()" style="width: 200px;">
     <md-option *ngFor="let status of statuses" [value]="status.value">{{ status.label | translate }}</md-option>
   </md-select>
   <h2>{{ getStatusString() | translate }}</h2>

--- a/client/components/orders/order-list.component.ts
+++ b/client/components/orders/order-list.component.ts
@@ -10,7 +10,8 @@ import { ApiRequestStatus } from '../../../../framework/client/rpc/rpc.interface
   templateUrl: 'order-list.component.html',
   styles: [ `.orders-content {
     padding: 16px;
-  }` ]
+  }
+  ` ]
 })
 export class OrderListComponent {
 

--- a/client/interfaces/nodes.interfaces.ts
+++ b/client/interfaces/nodes.interfaces.ts
@@ -2,10 +2,11 @@ import { SeeDocumentDetails } from './iyo-see.interfaces';
 
 export enum NodeOrderStatuses {
   CANCELED = -1,
-  CREATED = 0,
+  APPROVED = 0,
   SIGNED = 1,
   SENT = 2,
-  ARRIVED = 3
+  ARRIVED = 3,
+  WAITING_APPROVAL = 4,
 }
 
 export interface ContactInfo {
@@ -50,8 +51,9 @@ export interface GetNodeOrdersPayload {
 
 export const ORDER_STATUSES = {
   [ NodeOrderStatuses.CANCELED ]: 'tff.canceled',
-  [ NodeOrderStatuses.CREATED ]: 'tff.created',
+  [ NodeOrderStatuses.APPROVED ]: 'tff.approved',
   [ NodeOrderStatuses.SIGNED ]: 'tff.signed',
   [ NodeOrderStatuses.SENT ]: 'tff.sent',
   [ NodeOrderStatuses.ARRIVED ]: 'tff.arrived',
+  [ NodeOrderStatuses.WAITING_APPROVAL ]: 'tff.waiting_approval',
 };

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,6 +4,8 @@
     "add_currency": "Add currency",
     "address": "Address",
     "amount": "Amount",
+    "approve_order": "Approve order",
+    "approved": "Approved",
     "arrival_time": "Arrival time",
     "arrived": "Arrived",
     "auto_update": "Auto update",
@@ -14,12 +16,12 @@
     "cancel_time": "Cancel time",
     "canceled": "Canceled",
     "close": "Close",
-    "created": "Created",
     "currency": "Currency",
     "document_url": "Document url",
     "email": "Email",
     "errors": {
-      "invalid_currencies": "Invalid currencies: {{ currencies }}"
+      "invalid_currencies": "Invalid currencies: {{ currencies }}",
+      "invalid_status": "Invalid status"
     },
     "global_stats": "Global stats",
     "i_am_a_member": "I am a member",
@@ -33,7 +35,7 @@
     "mark_as_sent": "Mark as sent",
     "modification_time": "Modification time",
     "modified_on": "Modified on",
-    "name": "name",
+    "name": "Name",
     "node_order_x": "Node order {{ orderId }}",
     "order_detail": "Order detail",
     "order_time": "Order time",
@@ -59,6 +61,7 @@
     "user": "User",
     "value": "Value",
     "value_in_dollars": "Value in dollars",
+    "waiting_approval": "Waiting for approval",
     "x_tokens": "{{ count }} tokens"
   }
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -17,6 +17,7 @@
     "canceled": "Canceled",
     "close": "Close",
     "currency": "Currency",
+    "created": "Created",
     "document_url": "Document url",
     "email": "Email",
     "errors": {

--- a/plugins/tff_backend/bizz/agreements/assets/hosting.html
+++ b/plugins/tff_backend/bizz/agreements/assets/hosting.html
@@ -65,7 +65,7 @@
 <body>
 <!-- <style> -->
 <div id="footerContent" align="left">
-  Document Version 1.2
+  Document Version 1.3
 </div>
 
 <div id="p1">
@@ -105,7 +105,7 @@
 <pdf:nextpage/>
 <div id="p2">
     <p>3. Consideration</p>
-    <p>In consideration for the Services provided, the Company agrees to grant fifteen (15) ThreeFold Tokens per year to Host.
+    <p>In consideration for the Services provided, the Company agrees to grant six (6) ThreeFold Tokens per year to Host.
     The ThreeFold Tokens will be granted at the end of each relevant year on the anniversary date of this Agreement, provided the Host has duly completed its obligations set out under section 2 above.</p>
     <p>4. Term of this Agreement</p>
     <p>This Agreement is entered into for 5 years, unless terminated by either party in accordance with section 9 herein (the “Term”).</p>

--- a/plugins/tff_backend/bizz/hoster.py
+++ b/plugins/tff_backend/bizz/hoster.py
@@ -28,7 +28,7 @@ from mcfw.properties import object_factory
 from mcfw.rpc import returns, arguments, serialize_complex_value
 from plugins.rogerthat_api.api import qr, messaging, system
 from plugins.rogerthat_api.to import UserDetailsTO, MemberTO
-from plugins.rogerthat_api.to.messaging import AttachmentTO, Message
+from plugins.rogerthat_api.to.messaging import AttachmentTO, Message, AnswerTO
 from plugins.rogerthat_api.to.messaging.flow import FLOW_STEP_MAPPING
 from plugins.rogerthat_api.to.messaging.forms import SignTO, SignFormTO, FormResultTO, FormTO, SignWidgetResultTO
 from plugins.rogerthat_api.to.messaging.service_callback_results import FlowMemberResultCallbackResultTO, \
@@ -46,7 +46,9 @@ from plugins.tff_backend.bizz.rogerthat import put_user_data
 from plugins.tff_backend.bizz.service import get_main_branding_hash, add_user_to_role
 from plugins.tff_backend.bizz.todo import update_hoster_progress
 from plugins.tff_backend.bizz.todo.hoster import HosterSteps
+from plugins.tff_backend.consts.hoster import REQUIRED_TOKEN_COUNT_TO_HOST
 from plugins.tff_backend.models.hoster import NodeOrder, PublicKeyMapping, NodeOrderStatus, ContactInfo
+from plugins.tff_backend.models.investor import InvestmentAgreement
 from plugins.tff_backend.plugin_consts import KEY_NAME, KEY_ALGORITHM
 from plugins.tff_backend.to.iyo.see import IYOSeeDocumentView, IYOSeeDocumenVersion
 from plugins.tff_backend.to.nodes import NodeOrderTO, NodeOrderDetailsTO
@@ -62,10 +64,10 @@ from plugins.tff_backend.utils.app import create_app_user_by_email, get_app_user
 def order_node(message_flow_run_id, member, steps, end_id, end_message_flow_id, parent_message_key, tag, result_key,
                flush_id, flush_message_flow_id, service_identity, user_details, flow_params):
     order_key = NodeOrder.create_key()
-    deferred.defer(_order_node, order_key, user_details[0].email, user_details[0].app_id, steps, 0)
+    deferred.defer(_order_node, order_key, user_details[0].email, user_details[0].app_id, steps)
 
 
-def _order_node(order_key, user_email, app_id, steps, retry_count):
+def _order_node(order_key, user_email, app_id, steps):
     logging.info('Receiving order of Zero-Node')
     app_user = create_app_user_by_email(user_email, app_id)
 
@@ -86,7 +88,7 @@ def _order_node(order_key, user_email, app_id, steps, retry_count):
                                         phone=user_data['shipping_phone'],
                                         address=user_data['shipping_address'])
         else:
-            shipping_info = None
+            shipping_info = billing_info
 
         updated_user_data = None
     else:
@@ -108,7 +110,7 @@ def _order_node(order_key, user_email, app_id, steps, retry_count):
 
         same_shipping_info_step = get_step(steps, 'message_choose_shipping_info')
         if same_shipping_info_step and same_shipping_info_step.answer_id == u"button_yes":
-            shipping_info = None
+            shipping_info = billing_info
         else:
             shipping_name = get_step_value(steps, 'message_shipping_name')
             shipping_email = get_step_value(steps, 'message_shipping_email')
@@ -126,44 +128,86 @@ def _order_node(order_key, user_email, app_id, steps, retry_count):
                                         phone=shipping_phone,
                                         address=shipping_address)
 
-    logging.debug('Creating Hosting agreement')
-    pdf_name = 'node_%s.pdf' % order_key.id()
-    pdf_contents = create_hosting_agreement_pdf(billing_info.name, billing_info.address)
-    ipfs_link = store_pdf(pdf_name, pdf_contents)
-    if not ipfs_link:
-        logging.error(u"Failed to create IPFS document with name %s and retry_count %s", pdf_name, retry_count)
-        deferred.defer(_order_node, order_key, user_email, app_id, steps, retry_count + 1, _countdown=retry_count)
-        return
-
-    logging.debug('Storing order in the database')
+    # Check if user has invested >= 120 tokens
+    paid_orders = InvestmentAgreement.list_by_status_and_user(app_user, InvestmentAgreement.STATUS_PAID)
+    total_tokens = sum([o.token_count for o in paid_orders])
+    can_host = total_tokens >= REQUIRED_TOKEN_COUNT_TO_HOST
+    if can_host:
+        # Check if user has no previous node order. If so, send message stating that.
+        active_orders = [o for o in NodeOrder.list_by_user(app_user) if o.status != NodeOrderStatus.CANCELED]
+        can_host = len(active_orders) == 0
+        if not can_host:
+            logging.info('User already has a node order, sending abort message')
+            member_user, app_id = get_app_user_tuple(app_user)
+            msg = u'Dear ThreeFold Member, we sadly cannot grant your request to host an additional ThreeFold Node:' \
+                  u' We are currently only allowing one Node to be hosted per ThreeFold Member and location.' \
+                  u' This will allow us to build a bigger base and a more diverse Grid.'
+            messaging.send(api_key=get_rogerthat_api_key(),
+                           parent_message_key=None,
+                           members=[MemberTO(member=member_user.email(), app_id=app_id, alert_flags=0)],
+                           message=msg,
+                           answers=[
+                               AnswerTO(id='ok', caption='Ok', action=None, type='button', ui_flags=0, color=None)],
+                           flags=Message.FLAG_AUTO_LOCK,
+                           alert_flags=Message.ALERT_FLAG_VIBRATE,
+                           branding=get_main_branding_hash(),
+                           tag='no_multiple_node_orders_allowed')
+            return
 
     def trans():
+        logging.debug('Storing order in the database')
         order = NodeOrder(key=order_key,
                           app_user=app_user,
                           tos_iyo_see_id=None,
                           billing_info=billing_info,
                           shipping_info=shipping_info,
                           order_time=now(),
-                          status=NodeOrderStatus.CREATED)
+                          status=NodeOrderStatus.APPROVED if can_host else NodeOrderStatus.WAITING_APPROVAL)
         order.put()
-        deferred.defer(_create_order_arrival_qr, order_key.id(), _transactional=True)
-        deferred.defer(_order_node_iyo_see, app_user, order_key, ipfs_link, _transactional=True)
-        deferred.defer(update_hoster_progress, user_email, app_id, HosterSteps.FLOW_ADDRESS, _transactional=True)
-
+        if can_host:
+            logging.info('User has invested more than %s tokens, immediately creating node order PDF.',
+                         REQUIRED_TOKEN_COUNT_TO_HOST)
+            deferred.defer(_create_node_order_pdf, order_key.id(), _transactional=True)
+        else:
+            # TODO: Should probably notify admins of this order
+            logging.info('User has not invested more than %s tokens, an admin needs to approve this order manually.',
+                         REQUIRED_TOKEN_COUNT_TO_HOST)
         if updated_user_data:
             deferred.defer(put_user_data, app_user, updated_user_data, _transactional=True)
 
     ndb.transaction(trans)
 
 
-def _order_node_iyo_see(app_user, order_key, ipfs_link):
+def _create_node_order_pdf(node_order_id, retry_count=0):
+    """
+    Creates node order PDF on IPFS and sends it to
+    Args:
+        node_order_id (long)
+        retry_count (long)
+    """
+    node_order = get_node_order(node_order_id)
+    user_email, app_id = get_app_user_tuple(node_order.app_user)
+    logging.debug('Creating Hosting agreement')
+    pdf_name = 'node_%s.pdf' % node_order_id
+    pdf_contents = create_hosting_agreement_pdf(node_order.billing_info.name, node_order.billing_info.address)
+    ipfs_link = store_pdf(pdf_name, pdf_contents)
+    if not ipfs_link:
+        retry_count += 1
+        logging.info('Retrying creating IPFS PDF after %s tries', retry_count)
+        deferred.defer(_create_node_order_pdf, node_order_id, _countdown=retry_count)
+        return
+    deferred.defer(_create_order_arrival_qr, node_order_id)
+    deferred.defer(_order_node_iyo_see, node_order.app_user, node_order_id, ipfs_link)
+    deferred.defer(update_hoster_progress, user_email.email(), app_id, HosterSteps.FLOW_ADDRESS)
+
+
+def _order_node_iyo_see(app_user, node_order_id, ipfs_link):
     iyo_username = get_iyo_username(app_user)
     organization_id = get_iyo_organization_id()
 
     iyo_see_doc = IYOSeeDocumentView(username=iyo_username,
                                      globalid=organization_id,
-                                     uniqueid=u'Zero-Node order %s' % NodeOrder.create_human_readable_id(
-                                         order_key.id()),
+                                     uniqueid=u'Zero-Node order %s' % NodeOrder.create_human_readable_id(node_order_id),
                                      version=1,
                                      category=u'Terms and conditions',
                                      link=ipfs_link,
@@ -176,10 +220,10 @@ def _order_node_iyo_see(app_user, order_key, ipfs_link):
     attachment_name = u' - '.join([iyo_see_doc.uniqueid, iyo_see_doc.category])
 
     def trans():
-        order = order_key.get()
+        order = get_node_order(node_order_id)
         order.tos_iyo_see_id = iyo_see_doc.uniqueid
         order.put()
-        deferred.defer(_create_quotation, app_user, order_key.id(), ipfs_link, attachment_name,
+        deferred.defer(_create_quotation, app_user, node_order_id, ipfs_link, attachment_name,
                        _transactional=True)
 
     ndb.transaction(trans)
@@ -224,20 +268,13 @@ def _send_order_node_sign_message(app_user, order_id, ipfs_link, attachment_name
     attachment.content_type = u'application/pdf'
     attachment.download_url = ipfs_link
     attachment.name = attachment_name
-
     message = u"""Order %(order_name)s Received
 
-Thank you for your order.
-Your transaction is waiting confirmation.
-
-Please use the following transfer details
-Amount: USD 600 - Bank : Mashreq Bank - IBAN : AE230330000019120028156 - BIC : BOMLAEAD
-
-For the attention of Green IT Globe Holdings FZC, a company incorporated under the laws of Sharjah, United Arab Emirates, with registered office at SAIF Zone, SAIF Desk Q1-07-038/B
-Please use the SO number as reference.
+You have now been approved for hosting duties!
+We will keep you updated of the Node shipping process through the app.
 
 Please review the terms and conditions and press the "Sign" button to accept.
-""" % {"order_name": order_name}  # noQA
+""" % {"order_name": order_name}
 
     member_user, app_id = get_app_user_tuple(app_user)
     messaging.send_form(api_key=get_rogerthat_api_key(),
@@ -323,7 +360,6 @@ def order_node_signed(status, form_result, answer_id, member, message_key, tag, 
         # TODO: send mail to TF support
         deferred.defer(add_user_to_role, user_detail, Roles.HOSTERS)
         deferred.defer(update_hoster_progress, user_detail.email, user_detail.app_id, HosterSteps.FLOW_SIGN)
-        deferred.defer(send_payment_instructions, user_detail.email, user_detail.app_id, order.id)
 
         logging.debug('Sending confirmation message')
         message = MessageCallbackResultTypeTO()
@@ -334,9 +370,7 @@ def order_node_signed(status, form_result, answer_id, member, message_key, tag, 
         message.flags = Message.FLAG_ALLOW_DISMISS | Message.FLAG_AUTO_LOCK
         message.message = u'Thank you. We successfully received your digital signature.' \
                           u' We have stored a copy of this agreement in your ItsYou.Online SEE account.\n\n' \
-                          u'Your order with ID "%s" has been placed successfully.\n' \
-                          u'You can check the status of your order using' \
-                          u' the "Check on node transit" functionality.' % order.human_readable_id
+                          u'Your order with ID "%s" has been placed successfully.\n' % order.human_readable_id
         message.step_id = u'order_completed'
         message.tag = None
 
@@ -436,7 +470,7 @@ def put_node_order(order_id, order):
     order_model = get_node_order(order_id)
     if order_model.status == NodeOrderStatus.CANCELED:
         raise HttpBadRequestException('order_canceled')
-    if order.status not in (NodeOrderStatus.CANCELED, NodeOrderStatus.SENT):
+    if order.status not in (NodeOrderStatus.CANCELED, NodeOrderStatus.SENT, NodeOrderStatus.APPROVED):
         raise HttpBadRequestException('invalid_status')
     # Only support updating the status for now
     if order_model.status != order.status:
@@ -448,6 +482,10 @@ def put_node_order(order_id, order):
             human_user, app_id = get_app_user_tuple(order_model.app_user)
             deferred.defer(update_hoster_progress, human_user.email(), app_id, HosterSteps.NODE_SENT)
             deferred.defer(check_if_node_comes_online, order_id, _countdown=12 * 60 * 60)
+        elif order_model.status == NodeOrderStatus.APPROVED:
+            deferred.defer(_create_node_order_pdf, order_id)
+    else:
+        logging.debug('Status was already %s, not doing anything', order_model.status)
 
     order_model.put()
     return order_model
@@ -509,6 +547,7 @@ def check_if_node_comes_online(order_id):
 @returns()
 @arguments(email=unicode, app_id=unicode, order_id=(int, long))
 def send_payment_instructions(email, app_id, order_id):
+    """Currently unused since node orders are free"""
     order = get_node_order(order_id)
 
     message = u"""Please use the following transfer details

--- a/plugins/tff_backend/bizz/todo/hoster.py
+++ b/plugins/tff_backend/bizz/todo/hoster.py
@@ -24,7 +24,6 @@ class HosterSteps(object):
     FLOW_INIT = 'FLOW_INIT'
     FLOW_ADDRESS = 'FLOW_ADDRESS'
     FLOW_SIGN = 'FLOW_SIGN'
-    PAY = 'PAY'
     NODE_SENT = 'NODE_SENT'
     NODE_DELIVERY_CONFIRMED = 'NODE_DELIVERY_CONFIRMED'
     NODE_POWERED = 'NODE_POWERED'
@@ -35,7 +34,6 @@ class HosterSteps(object):
         FLOW_INIT: 'Initiate “become a hoster process” in the TF app',
         FLOW_SIGN: 'Sign the hoster agreement',
         FLOW_ADDRESS: 'Share shipping address, telephone number, name with shipping company',
-        PAY: 'Make payment',
         NODE_SENT: 'Receive confirmation of sending',
         NODE_DELIVERY_CONFIRMED: 'Confirm delivery of node',
         NODE_POWERED: 'Hook up node to Internet and power',
@@ -48,7 +46,6 @@ class HosterSteps(object):
                 cls.FLOW_INIT,
                 cls.FLOW_ADDRESS,
                 cls.FLOW_SIGN,
-                cls.PAY,
                 cls.NODE_SENT,
                 cls.NODE_DELIVERY_CONFIRMED,
                 cls.NODE_POWERED]

--- a/plugins/tff_backend/consts/hoster.py
+++ b/plugins/tff_backend/consts/hoster.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 GIG Technology NV
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# @@license_version:1.3@@
+REQUIRED_TOKEN_COUNT_TO_HOST = 120

--- a/plugins/tff_backend/models/investor.py
+++ b/plugins/tff_backend/models/investor.py
@@ -58,6 +58,17 @@ class InvestmentAgreement(NdbModel):
             .filter(cls.status == status)
 
     @classmethod
+    def list_by_user(cls, app_user):
+        return cls.query() \
+            .filter(cls.app_user == app_user)
+
+    @classmethod
+    def list_by_status_and_user(cls, app_user, statuses):
+        # type: (users.User, int) -> list[InvestmentAgreement]
+        statuses = [statuses] if isinstance(statuses, int) else statuses
+        return [investment for investment in cls.list_by_user(app_user) if investment.status in statuses]
+
+    @classmethod
     def fetch_page(cls, cursor=None, status=None):
         # type: (unicode) -> tuple[list[InvestmentAgreement], ndb.Cursor, bool]
         qry = cls.list_by_status(status) if status is not None else cls.list()


### PR DESCRIPTION
- Sends hoster agreement to user if user has InvestmentAgreements marked as paid for a total of more than 120 tokens worth AND user has no preexisting Hoster agreement
- If not, flag for manual check (currently here to support legacy investments made outside the app)
- An error message is sent when user already had an existing hoster agreement that hasn't been canceled
- If order is approved by admin (via UI), the hoster agreement is sent to the user.

Closes #135 
Closes #136